### PR TITLE
[for discussion] Simplify API

### DIFF
--- a/raml/notify.raml
+++ b/raml/notify.raml
@@ -1,0 +1,65 @@
+# RAML 0.0
+title:
+version: v1
+baseUrl: http://example.com/api
+/notify:
+  post:
+    description: Create a notification
+    responses:
+      200:
+    body:
+      application/json:
+        schema |
+          {"$schema": “http://json-schema.org/schema”,
+            "type":"object",
+            "description": "Alert Data",
+            "properties": {
+              "environment": {"type": "string"},
+              "severity":    {"enum": ["OK", "INFO", "UNKNOWN", "WARNING", "CRITICAL", "DOWN"]},
+              "description": {"type": "string"},
+              "who":         {"type": "array"}, # list of hosts or cluster(s)
+              "what":        {"type": "string"}, # service
+              "type":        {"enum": ["PROBLEM", "RECOVERY"]}, # (optional)
+              "datetime":    {"type": "datetime"} # (optional) rfc3339 or current date if not provided
+            },
+            "required": ["environment", "severity", "description", "who", "what"]
+          example: |
+          {
+            "notif" : {
+              "environment": "XxXxXxX"
+              "severity": "CRITICAL",
+              "type": "PROBLEM",
+              "description": "
+                    (CRITICAL, rule=avg(cpu_idle)=5, current=1.65, host=ic3-ctl02) \n
+                    No datapoint have been received over the last 60 seconds \n
+                    (UNKNOWN, rule=min(fs_space_percent_free[fs=/var/log])2, \n
+                    current=-1.00, host=ic3-ctl03)"
+              "who": [
+                  "ic3-ctl01",
+                  "ic3-ctl02",
+                  "ic3-ctl03"
+              ],
+              "what": "glance-api",
+              "datetime": "2016-12-02T14:14:53Z"
+            },
+            "success": true,
+            "status": 200
+          }
+
+          {
+            "notif" : {
+              "environment": "XxXxXxX"
+              "severity": "WARNING",
+              "type": "PROBLEM",
+              "description": "
+              Nova API is locally down (DOWN, rule='last(openstack_check_local_api[service="nova-api"])==0', current=0.00, host=ctl01)"
+              "who": [
+                  "ctl01",
+              ],
+              "what": "nova_control",
+              "datetime": "2016-12-02T14:14:53Z"
+            },
+            "success": true,
+            "status": 200
+            }
+        }


### PR DESCRIPTION
The current proposition is too close to the current implementation of
the Nagios/SFDC couple.

* rename /alert to /notify
* rename property
 * priority -> severity
 * service -> what
 * host -> who
* remove properties:
 * 'alertId': this must be handled by the 'notify' service itself
  * 'subject': redundant
* add properties:
  * 'type' is the type of the notification (optional)
  * 'datetime' (optional)
  * 'entity': the entity type (a Host, a Cluster of services, a
  * Cluster of nodes ..)